### PR TITLE
Remove the Bazel repository cache

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -100,7 +100,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      # Cache build and external artifacts so that the next ci build is incremental.
+      # Cache build artifacts so that the next ci build is incremental.
       # Because github action caches cannot be updated after a build, we need to
       # store the contents of each build in a unique cache key, then fall back to loading
       # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
@@ -111,12 +111,14 @@ jobs:
       # In the case of a cache miss, you want the fallback cache to contain most of the
       # previously built artifacts to minimize build time. The more precise you are with
       # hashFiles sources the less work bazel will have to do.
+      # We do not cache downloaded external artifacts as these are generally
+      # faster to download again than to fetch them from the GitHub actions
+      # cache.
       - name: Mount bazel caches
         uses: actions/cache@v3
         with:
           path: |
             ~/.cache/bazel
-            ~/.cache/bazel-repo
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
 
@@ -141,7 +143,7 @@ jobs:
 
       - name: bazel test //...
         env:
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          # Bazelisk will download bazel to here.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: ${{ matrix.folder }}
         run: bazel --bazelrc=${{ github.workspace }}/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -33,12 +33,11 @@ jobs:
         with:
           path: |
             ~/.cache/bazel
-            ~/.cache/bazel-repo
           key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
       - name: bazel test //...
         env:
-          # Bazelisk will download bazel to here
+          # Bazelisk will download bazel to here.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
       - name: Prepare release notes and artifacts


### PR DESCRIPTION
Closes https://github.com/bazel-contrib/rules-template/issues/76

Disables the Bazel repository cache. See https://github.com/bazel-contrib/rules-template/issues/76 for motivation.
