### PR TITLE
Update reusable GHA workflow to Bazel 6+7

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -22,8 +22,7 @@ on:
         description: |
           JSON-formatted array of exclusions to the generated matrix of tests.
 
-          By default, we don't test bzlmod with Bazel 5 (not supported)
-          and we don't test non-linux with Bazel 5 to minimize macOS and Windows minutes
+          By default, we don't test non-linux with Bazel 6 to minimize macOS and Windows minutes
           since they are billed at 10X and 2X respectively:
           https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
           
@@ -32,9 +31,8 @@ on:
         type: string
         default: |
           [
-            {"bazelversion": "5.4.0", "bzlmodEnabled": true},
-            {"bazelversion": "5.4.0", "os": "macos-latest"},
-            {"bazelversion": "5.4.0", "os": "windows-latest"}
+            {"bazelversion": "6.4.0", "os": "macos-latest"},
+            {"bazelversion": "6.4.0", "os": "windows-latest"}
           ]
       exclude_windows:
         description: Don't run any tests on Windows
@@ -69,12 +67,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
-      - id: bazel_5
-        run: echo "bazelversion=5.4.0" >> $GITHUB_OUTPUT
+      - id: bazel_6
+        run: echo "bazelversion=6.4.0" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      # Will look like ["<version from .bazelversion>", "x.y.z"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   test:
@@ -98,7 +97,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Cache build artifacts so that the next ci build is incremental.
       # Because github action caches cannot be updated after a build, we need to


### PR DESCRIPTION
This replaces the assumption that rules are testing with 5+6