### PR TITLE
feat: release workflow allows tag_name specified

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -41,6 +41,9 @@ on:
         default: true
         description: Indicator of whether or not this is a prerelease.
         type: boolean
+      tag_name:
+        description: the tag to apply. defaults to `github.ref`
+        type: string
 
 jobs:
   build:
@@ -75,3 +78,4 @@ jobs:
           body_path: release_notes.txt
           fail_on_unmatched_files: true
           files: ${{ inputs.release_files }}
+          tag_name: ${{ inputs.tag_name || github.ref }}

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -78,4 +78,4 @@ jobs:
           body_path: release_notes.txt
           fail_on_unmatched_files: true
           files: ${{ inputs.release_files }}
-          tag_name: ${{ inputs.tag_name || github.ref }}
+          tag_name: ${{ inputs.tag_name || github.ref_name }}

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -42,7 +42,9 @@ on:
         description: Indicator of whether or not this is a prerelease.
         type: boolean
       tag_name:
-        description: the tag to apply. defaults to `github.ref`
+        description: |
+          The tag which is being released.
+          By default, https://github.com/softprops/action-gh-release will use `github.tag_name`.
         type: string
 
 jobs:
@@ -78,4 +80,4 @@ jobs:
           body_path: release_notes.txt
           fail_on_unmatched_files: true
           files: ${{ inputs.release_files }}
-          tag_name: ${{ inputs.tag_name || github.ref_name }}
+          tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -44,7 +44,7 @@ on:
       tag_name:
         description: |
           The tag which is being released.
-          By default, https://github.com/softprops/action-gh-release will use `github.tag_name`.
+          By default, https://github.com/softprops/action-gh-release will use `github.ref_name`.
         type: string
 
 jobs:


### PR DESCRIPTION
This is needed when the workflow is triggered without a `push` or `tag` event. For example, I'm planning to add a GitHub Actions workflow that can apply a tag, then it triggers this workflow.