### PR TITLE
fix: pass correct tag name to release script

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -69,7 +69,7 @@ jobs:
             echo "ERROR: create a ${{ inputs.release_prep_command }} release prep script or configure a different release prep command with the release_prep_command attribute"
             exit 1
           fi
-          ${{ inputs.release_prep_command }} ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+          ${{ inputs.release_prep_command }} ${{ inputs.tag_name || env.GITHUB_REF_NAME }} > release_notes.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
If it was created by a workflow_dispatch then the argument should match