### PR TITLE
fix release_ruleset.yaml

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -71,7 +71,7 @@ jobs:
             echo "ERROR: create a ${{ inputs.release_prep_command }} release prep script or configure a different release prep command with the release_prep_command attribute"
             exit 1
           fi
-          ${{ inputs.release_prep_command }} ${{ inputs.tag_name || env.GITHUB_REF_NAME }} > release_notes.txt
+          ${{ inputs.release_prep_command }} ${{ inputs.tag_name || github.ref_name }} > release_notes.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Somehow the environment isn't present, as evidenced by rules_lint.
Confirmed this fix downstream - https://github.com/aspect-build/rules_lint/pull/467 released successfully.