### PR TITLE
fix: check that patches apply exactly

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -142,7 +142,7 @@ jobs:
       # See https://github.com/bazel-contrib/publish-to-bcr#including-patches
       - name: verify bcr patches
         if: matrix.bzlmodEnabled && hashFiles('.bcr/patches/*.patch') != '' && ! startsWith(matrix.os, 'windows')
-        run: patch --dry-run -p1 < .bcr/patches/*.patch
+        run: patch --dry-run -p1 --fuzz 0 < .bcr/patches/*.patch
 
       - name: Test
         working-directory: ${{ matrix.folder }}


### PR DESCRIPTION
See https://github.com/aspect-build/rules_py/pull/508 where the absence of this flag allowed a broken rules_py release