### PR TITLE
Attest release archives and publish to the BCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,222 @@
+# Reusable workflow that can be referenced by repositories in their `.github/workflows/publish.yaml`.
+# See example usage in https://github.com/bazel-contrib/rules-template/blob/main/.github/workflows/release.yaml
+# where the is invoked automatically after a successful release, and can be invoked manually.
+#
+# This script uses Publish to BCR (https://github.com/bazel-contrib/publish-to-bcr) to generate a BCR entry for
+# a tagged release, uploads attestations for the generated source.json and MODULE.bazel files to the release,
+# and opens up a pull request against the Bazel Central Registry (https://github.com/bazelbuild/bazel-central-registry).
+#
+# The workflow requires the following permissions to be set on the invoking job:
+#
+# permissions:
+#   id-token: write        # Needed for attesting
+#   attestations: write    # Needed for attesting
+#   contents: write        # Needed for uploading release files
+#
+# The workflow additionally requires a Classic Personal Access Token (PAT) to be supplied in the `publish_token`
+# input. The PAT is necessary to push to your BCR fork as well as to open up a pull request against a registry.
+# At the moment, fine-grained PATs are not supported because they cannot open pull requests against public 
+# repositories, although this is on GitHub's roadmap: https://github.com/github/roadmap/issues/600.
+#
+# The module repository must contain a .bcr folder containing Publish to BCR templates.
+# See https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates.
+#
+# Repositories containing multiple modules that are versioned together will have all modules included in
+# the published entry. This is controlled via the `moduleRoots` property in .bcr/config.yml.
+
+on:
+  # Make this workflow reusable, see
+  # https://github.blog/2022-02-10-using-reusable-workflows-github-actions
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        description: The tag identifying the release the publish to a Bazel registry.
+        type: string
+      registry_fork:
+        required: true
+        description: The Bazel registry fork to push to when opening up a pull request, e.g. "mycompany/bazel-central-registry"
+        type: string
+      registry:
+        description: The Bazel registry to open up a pull request against. Defaults to the Bazel Central Registry.
+        default: bazelbuild/bazel-central-registry
+        type: string
+      repository:
+        description: The Bazel module repository to publish an entry for. Defaults the the repository the action runs in.
+        default: ${{ github.repository }}
+        type: string
+      registry_branch:
+        description: The branch of the Bazel registry to open a PR against. Defaults to main.
+        default: main
+        type: string
+    secrets:
+      publish_token:
+        required: true
+        description: A Classic Personal Access Token (PAT) used for pushing to a registry fork and opening up a pull request.
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the module repository
+      uses: actions/checkout@v4.2.2
+      with:
+        ref: ${{ github.event.inputs.tag_name }}
+        repository: ${{ inputs.repository }}
+        path: this
+
+    - name: Checkout BCR
+      uses: actions/checkout@v4.2.2
+      with:
+        repository: ${{ github.event.inputs.registry }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: bazel-central-registry
+
+    # Get version from the tag, stripping any v-prefix
+    - name: Write release version
+      env:
+        TAG: ${{ inputs.tag_name }}
+      run: |
+        VERSION=${TAG#v}
+        echo Version: $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    # Remove any pre-existing attestations.template.json files so that the following (dummy) entry
+    # creation for generating attestations will succeed without trying to substitute and verify
+    # existing attestations. Any existing templates will be restored when the final entry is created.
+    - name: Remove attestations.template.json
+      working-directory: this/.bcr
+      run: find . -type f -name 'attestations.template.json' -delete
+
+    # Create an initial entry so that we can attest the generated source.json and MODULE.bazel
+    # files. These are needed to solve a chicken and egg problem where the attestations are referenced
+    # by attestations.template.json entry file, which is included in the entry published later on.
+    # This entry will be discarded.
+    - name: Create entry
+      id: create-entry
+      uses: bazel-contrib/publish-to-bcr@fa7d3c8ad241c2c0cde639eb2225be55816e9565
+      with:
+        attest: true
+        attestations-dest: attestations
+        tag: ${{ inputs.tag_name }}
+        module-version: ${{ env.VERSION }}
+        local-registry: bazel-central-registry
+        templates-dir: this/.bcr
+
+    # Upload the attestations to the release. This will override attestations that
+    # were already uploaded on a previous run.
+    - name: Upload attestations to release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: attestations/*
+        repository: ${{ inputs.repository }}
+        tag_name: ${{ inputs.tag_name }}
+
+    # Publish to BCR can run substitutions on an attestations.template.json file. Add a default
+    # template here and don't require it to exist in the module repo's .bcr templates folder.
+    - name: Create attestations template
+      working-directory: this/.bcr
+      run: |
+        # Determine whether this is a multi-module repo because it affects the names of the
+        # uploaded attestaton files.
+        if [ -f "config.yml" ]; then
+            readarray -t MODULE_ROOTS < <(cat "config.yml" | yq --unwrapScalar '.moduleRoots.[]')
+        elif [ -f "config.yaml" ]; then
+            readarray -t MODULE_ROOTS < <(cat "config.yaml" | yq --unwrapScalar '.moduleRoots.[]')
+        else
+            MODULE_ROOTS=(".")
+        fi
+
+        # Read comma-delimited module names into an array
+        IFS=',' read -r -a MODULE_NAMES <<< "${{ steps.create-entry.outputs.module-names }}"
+
+        for i in "${!MODULE_ROOTS[@]}"; do 
+            MODULE_ROOT="${MODULE_ROOTS[$i]}"
+            if [ ! -f "${MODULE_ROOT}/attestations.template.json" ]; then
+                # Multi-module repos upload attestations with the module name as a prefix
+                if [ "${#MODULE_ROOTS[@]}" -gt "1" ]; then
+                  PREFIX="${MODULE_NAMES[$i]}."
+                else
+                  PREFIX=""
+                fi
+                RELEASE_ARCHIVE_URL=$(cat "${MODULE_ROOT}/source.template.json" | jq --raw-output '.url')
+                cat <<EOF >"${MODULE_ROOT}/attestations.template.json"
+        {
+            "mediaType": "application/vnd.build.bazel.registry.attestation+json;version=1.0.0",
+            "attestations": {
+                "source.json": {
+                    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/${PREFIX}source.json.intoto.jsonl",
+                    "integrity": ""
+                },
+                "MODULE.bazel": {
+                    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/${PREFIX}MODULE.bazel.intoto.jsonl",
+                    "integrity": ""
+                },
+                "$(basename ${RELEASE_ARCHIVE_URL})": {
+                    "url": "${RELEASE_ARCHIVE_URL}.intoto.jsonl",
+                    "integrity": ""
+                }
+            }
+        }
+        EOF
+            fi
+        done
+
+    - name: Discard previous entry
+      working-directory: bazel-central-registry
+      run: git clean -ffxd
+
+    # Create the final BCR entry that we will publish
+    - name: Create entry with attestations.json
+      id: create-entry-with-att
+      uses: bazel-contrib/publish-to-bcr@fa7d3c8ad241c2c0cde639eb2225be55816e9565
+      with:
+        tag: ${{ github.event.inputs.tag_name }}
+        module-version: ${{ env.VERSION }}
+        local-registry: bazel-central-registry
+        templates-dir: this/.bcr
+    
+    - name: Set PR details
+      id: set-pr-details
+      run: |
+        BRANCH_NAME="$(echo "${{ steps.create-entry-with-att.outputs.module-names }}" | sed "s/,/_/")-${{ inputs.tag_name }}"
+
+        # Read comma-delimited module names into an array
+        IFS=',' read -r -a MODULE_NAMES <<< "${{ steps.create-entry.outputs.module-names }}"
+        if [ "${#MODULE_NAMES[@]}" -gt "1" ]; then
+          COMMIT_MSG="Publish {${{ steps.create-entry-with-att.outputs.module-names }}}@${{ env.VERSION }}"
+          PR_TITLE="Publish {${{ steps.create-entry-with-att.outputs.module-names }}}@${{ env.VERSION }}"
+        else
+          COMMIT_MSG="Publish ${{ steps.create-entry-with-att.outputs.module-names }}@${{ env.VERSION }}"
+          PR_TITLE="Publish ${{ steps.create-entry-with-att.outputs.module-names }}@${{ env.VERSION }}"
+        fi
+
+        echo "Branch name: ${BRANCH_NAME}"
+        echo "Commit message: ${COMMIT_MSG}"
+        echo "PR title: ${PR_TITLE}"
+        
+        echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+        echo "commit_msg=${COMMIT_MSG}" >> $GITHUB_OUTPUT
+        echo "pr_title=${PR_TITLE}" >> $GITHUB_OUTPUT
+
+    - name: Create Pull Request
+      id: create-pull-request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.publish_token }}
+        path: bazel-central-registry
+        commit-message: ${{ steps.set-pr-details.outputs.commit_msg }}
+        base: ${{ inputs.registry_branch }}
+        branch: ${{ steps.set-pr-details.outputs.branch_name }}
+        push-to-fork: ${{ inputs.registry_fork }}
+        title: ${{ steps.set-pr-details.outputs.pr_title }}
+        body: |
+          Release: https://github.com/${{ inputs.repository }}/releases/tag/${{ inputs.tag_name }}
+
+          _Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_
+        maintainer-can-modify: true
+
+    - uses: peter-evans/enable-pull-request-automerge@v3
+      with:
+        token: ${{ secrets.publish_token }}
+        pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        repository: ${{ inputs.registry }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,9 +9,9 @@
 # The workflow requires the following permissions to be set on the invoking job:
 #
 # permissions:
-#   id-token: write        # Needed for attesting
-#   attestations: write    # Needed for attesting
-#   contents: write        # Needed for uploading release files
+#   id-token: write        # Needed to attest provenance
+#   attestations: write    # Needed to attest provenance
+#   contents: write        # Needed to upload release files
 #
 # The workflow additionally requires a Classic Personal Access Token (PAT) to be supplied in the `publish_token`
 # input. The PAT is necessary to push to your BCR fork as well as to open up a pull request against a registry.
@@ -31,7 +31,7 @@ on:
     inputs:
       tag_name:
         required: true
-        description: The tag identifying the release the publish to a Bazel registry.
+        description: The git tag identifying the release the publish to a Bazel registry.
         type: string
       registry_fork:
         required: true
@@ -49,10 +49,15 @@ on:
         description: The branch of the Bazel registry to open a PR against. Defaults to main.
         default: main
         type: string
+      templates_ref:
+        description: |
+          The git ref to read BCR templates (.bcr folder) rather than reading them from `tag_name`.
+          Use this to republish a release whose templates had errors.
+        type: string
     secrets:
       publish_token:
         required: true
-        description: A Classic Personal Access Token (PAT) used for pushing to a registry fork and opening up a pull request.
+        description: A Personal Access Token (PAT) used for pushing to a registry fork and opening up a pull request.
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -60,14 +65,14 @@ jobs:
     - name: Checkout the module repository
       uses: actions/checkout@v4.2.2
       with:
-        ref: ${{ github.event.inputs.tag_name }}
+        ref: ${{ inputs.templates_ref || inputs.tag_name }}
         repository: ${{ inputs.repository }}
         path: this
 
     - name: Checkout BCR
       uses: actions/checkout@v4.2.2
       with:
-        repository: ${{ github.event.inputs.registry }}
+        repository: ${{ inputs.registry }}
         token: ${{ secrets.GITHUB_TOKEN }}
         path: bazel-central-registry
 
@@ -112,9 +117,13 @@ jobs:
         tag_name: ${{ inputs.tag_name }}
 
     # Publish to BCR can run substitutions on an attestations.template.json file. Add a default
-    # template here and don't require it to exist in the module repo's .bcr templates folder.
+    # template here rather than requiring users to add one the module repo's .bcr templates folder.
     - name: Create attestations template
       working-directory: this/.bcr
+      # Ideally this would be in its own file, but it's not currently trivial to source files from a
+      # reusable workflow in a different repository:
+      # https://github.com/orgs/community/discussions/63863
+      # https://github.com/orgs/community/discussions/18602
       run: |
         # Determine whether this is a multi-module repo because it affects the names of the
         # uploaded attestaton files.
@@ -170,7 +179,7 @@ jobs:
       id: create-entry-with-att
       uses: bazel-contrib/publish-to-bcr@fa7d3c8ad241c2c0cde639eb2225be55816e9565
       with:
-        tag: ${{ github.event.inputs.tag_name }}
+        tag: ${{ inputs.tag_name }}
         module-version: ${{ env.VERSION }}
         local-registry: bazel-central-registry
         templates-dir: this/.bcr

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -2,8 +2,8 @@
 # See example usage in https://github.com/bazel-contrib/rules-template/blob/main/.github/workflows/release.yaml
 #
 # By default this workflows calls `.github/workflows/release_prep.sh` as the command to prepare
-# the release. This can be customized with the `release_prep_command` attribute. See documentation
-# for the `release_prep_command` property below for inputs and outputs of the script.
+# the release. This can be customized with the `release_prep_command` attribute. Release notes are
+# expected to be outputted to stdout from the release prep command.
 #
 # This workflow uses https://github.com/bazel-contrib/setup-bazel to prepare the cache folders.
 # Caching may be disabled by setting `mount_bazel_caches` to false.
@@ -11,38 +11,29 @@
 # The workflow requires the following permissions to be set on the invoking job:
 #
 # permissions:
-#   contents: write        # Needed for uploading release files
-
+#   id-token: write        # Needed to attest provenance
+#   attestations: write    # Needed to attest provenance
+#   contents: write        # Needed to upload release files
 
 on:
   # Make this workflow reusable, see
   # https://github.blog/2022-02-10-using-reusable-workflows-github-actions
   workflow_call:
     inputs:
+      release_files:
+        required: true
+        description: |
+          Newline-delimited globs of paths to assets to upload for release.
+          relative to the module repository. The paths should include any files
+          such as a release archive created by the `release_prep_command`.
+
+          See https://github.com/softprops/action-gh-release#inputs.
+        type: string
       release_prep_command:
         default: .github/workflows/release_prep.sh
         description: |
           Command to run to prepare the release and generate release notes.
-
-          The script will be provided with the following env vars:
-
-            ARTIFACTS_DIR: Path to a pre-created directory where all artifacts to be
-            uploaded to the GitHub release must be placed.
-
-            RELEASE_NOTES: Path to a pre-created file where release notes content should
-            be written.
-
-          The following arguments are passed to the script:
-
-            <tag_or_ref> The tag supplied as an input to this workflows, or `github.ref_name`.
-
-          The script must output a JSON blob with paths to release archives. The path can
-          be absolute or relative to the ARTIFACTS_DIR. For example:
-
-          {
-            "release_archives": ["my-ruleset-vX.Y.Z.tar.gz"]
-          }
-
+          Release notes are expected to be outputted to stdout.
         type: string
       bazel_test_command:
         default: "bazel test //..."
@@ -74,64 +65,49 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag_name }}
-          path: this
 
       - uses: bazel-contrib/setup-bazel@0.14.0
         with:
-          module-root: this
           disk-cache: ${{ inputs.mount_bazel_caches }}
           external-cache: ${{ inputs.mount_bazel_caches }}
           repository-cache: ${{ inputs.mount_bazel_caches }}
 
       - name: Test
-        working-directory: this
         run: ${{ inputs.bazel_test_command }} --disk_cache=~/.cache/bazel-disk-cache --repository_cache=~/.cache/bazel-repository-cache
 
-      - name: Release preparation
-        id: release_prep
-        working-directory: this
+      - name: Build release artifacts and prepare release notes
         run: |
           if [ ! -f "${{ inputs.release_prep_command }}" ]; then
             echo "ERROR: create a ${{ inputs.release_prep_command }} release prep script or configure a different release prep command with the release_prep_command attribute"
             exit 1
           fi
+          ${{ inputs.release_prep_command }} ${{ inputs.tag_name || github.ref_name }} > release_notes.txt
 
-          export ARTIFACTS_DIR=$(mktemp --directory)
-          export RELEASE_NOTES=$(mktemp)
-          OUTPUT=$(${{ inputs.release_prep_command }} ${{ inputs.tag_name || github.ref_name }} | jq --compact-output .)
-
-          echo "Release prep output:"
-          echo "${OUTPUT}"
-
-          # Parse the the release archives, making the paths absolute
-          # Store a comma-delimited list which is the format required by the `subject-path`
-          # input in actions/attest-build-provenance.
-          RELEASE_ARCHIVES=$(echo "${OUTPUT}" | jq --raw-output --arg artifactsDir "${ARTIFACTS_DIR}/" '.release_archives[] |= sub("^(?<path>[^/].*)";"\($artifactsDir)\(.path)") | .release_archives[]' | tr '\n' ',' | sed '$s/,$//')
-
-          echo "artifacts_dir=$ARTIFACTS_DIR" >> $GITHUB_OUTPUT
-          echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
-          echo "release_archives=$RELEASE_ARCHIVES" >> $GITHUB_OUTPUT
-
-      # The actions/attest-build-provenance action can only produce a single attestation with multiple
-      # subjects, rather than an attestation per subject, which we want. Create a single attestation
-      # with all release archives, then copy the same attestation to multiple files below.
-      - name: Attest release archive(s) provenance
-        id: attest_release_archive
+      # https://github.com/actions/attest-build-provenance
+      - name: Attest release files
+        id: attest_release
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: ${{ steps.release_prep.outputs.release_archives }}
+          subject-path: ${{ inputs.release_files }}
       
-      - name: Write release archive(s) attestation into intoto.jsonl
+      # The Bazel Central Registry requires an attestation per release archive, but the
+      # actions/attest-build-provenance action only produces a single attestation for a
+      # list of subjects. Copy the combined attestations into individually named
+      # .intoto.jsonl files.
+      - name: Write release archive attestations into intoto.jsonl
         id: write_release_archive_attestation
         run: |
+          # https://bazel.build/rules/lib/repo/http#http_archive
+          RELEASE_ARCHIVE_REGEX="(.zip|.jar|.war|.aar|.tar|.tar.gz|.tgz|.tar.xz|.txz|.tar.xzt|.tzst|.tar.bz2|.ar|.deb)$"
+
           ATTESTATIONS_DIR=$(mktemp --directory)
-          RELEASE_ARCHIVES="${{ steps.release_prep.outputs.release_archives }}"
-          SPACE_DELIMITED="${RELEASE_ARCHIVES//,/ }"
-          for ARCHIVE in $SPACE_DELIMITED; do
-              echo "${ARCHIVE}"
-              ATTESTATION_FILE="$(basename "${ARCHIVE}").intoto.jsonl"
-              echo "Writing attestation to ${ATTESTATION_FILE}"
-              cat ${{ steps.attest_release_archive.outputs.bundle-path }} | jq --compact-output > "${ATTESTATIONS_DIR}/${ATTESTATION_FILE}"
+          RELEASE_FILES="${{ join(inputs.release_files, ' ') }}"
+          for filename in $RELEASE_FILES; do
+            if [[ "${filename}" =~ $RELEASE_ARCHIVE_REGEX ]]; then
+                ATTESTATION_FILE="$(basename "${filename}").intoto.jsonl"
+                echo "Writing attestation to ${ATTESTATION_FILE}"
+                cat ${{ steps.attest_release.outputs.bundle-path }} | jq --compact-output > "${ATTESTATIONS_DIR}/${ATTESTATION_FILE}"
+            fi
           done
           echo "release_archive_attestations_dir=${ATTESTATIONS_DIR}" >> $GITHUB_OUTPUT
 
@@ -141,9 +117,9 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
-          body_path: ${{ steps.release_prep.outputs.release_notes }}
+          body_path: release_notes.txt
           fail_on_unmatched_files: true
-          files: |
-            ${{ steps.release_prep.outputs.artifacts_dir }}/*
-            ${{ steps.write_release_archive_attestation.outputs.release_archive_attestations_dir }}/*
           tag_name: ${{ inputs.tag_name }}
+          files: |
+            ${{ inputs.release_files }}
+            ${{ steps.write_release_archive_attestation.outputs.release_archive_attestations_dir }}/*

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -2,28 +2,47 @@
 # See example usage in https://github.com/bazel-contrib/rules-template/blob/main/.github/workflows/release.yaml
 #
 # By default this workflows calls `.github/workflows/release_prep.sh` as the command to prepare
-# the release. This can be customized with the `release_prep_command` attribute. Release notes are
-# expected to be outputted to stdout from the release prep command.
+# the release. This can be customized with the `release_prep_command` attribute. See documentation
+# for the `release_prep_command` property below for inputs and outputs of the script.
 #
 # This workflow uses https://github.com/bazel-contrib/setup-bazel to prepare the cache folders.
 # Caching may be disabled by setting `mount_bazel_caches` to false.
+#
+# The workflow requires the following permissions to be set on the invoking job:
+#
+# permissions:
+#   contents: write        # Needed for uploading release files
+
 
 on:
   # Make this workflow reusable, see
   # https://github.blog/2022-02-10-using-reusable-workflows-github-actions
   workflow_call:
     inputs:
-      release_files:
-        required: true
-        description: |
-          Newline-delimited globs of paths to assets to upload for release.
-          See https://github.com/softprops/action-gh-release#inputs
-        type: string
       release_prep_command:
         default: .github/workflows/release_prep.sh
         description: |
           Command to run to prepare the release and generate release notes.
-          Release notes are expected to be outputted to stdout.
+
+          The script will be provided with the following env vars:
+
+            ARTIFACTS_DIR: Path to a pre-created directory where all artifacts to be
+            uploaded to the GitHub release must be placed.
+
+            RELEASE_NOTES: Path to a pre-created file where release notes content should
+            be written.
+
+          The following arguments are passed to the script:
+
+            <tag_or_ref> The tag supplied as an input to this workflows, or ${{ github.ref_name }}.
+
+          The script must output a JSON blob with paths to release archives. The path can
+          be absolute or relative to the ARTIFACTS_DIR. For example:
+
+          {
+            "release_archives": ["my-ruleset-vX.Y.Z.tar.gz"]
+          }
+
         type: string
       bazel_test_command:
         default: "bazel test //..."
@@ -55,23 +74,66 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag_name }}
+          path: this
 
-      - uses: bazel-contrib/setup-bazel@0.8.0
+      - uses: bazel-contrib/setup-bazel@0.14.0
         with:
+          module-root: this
           disk-cache: ${{ inputs.mount_bazel_caches }}
           external-cache: ${{ inputs.mount_bazel_caches }}
           repository-cache: ${{ inputs.mount_bazel_caches }}
 
       - name: Test
+        working-directory: this
         run: ${{ inputs.bazel_test_command }} --disk_cache=~/.cache/bazel-disk-cache --repository_cache=~/.cache/bazel-repository-cache
 
-      - name: Build release artifacts and prepare release notes
+      - name: Release preparation
+        id: release_prep
+        working-directory: this
         run: |
           if [ ! -f "${{ inputs.release_prep_command }}" ]; then
             echo "ERROR: create a ${{ inputs.release_prep_command }} release prep script or configure a different release prep command with the release_prep_command attribute"
             exit 1
           fi
-          ${{ inputs.release_prep_command }} ${{ inputs.tag_name || github.ref_name }} > release_notes.txt
+
+          export ARTIFACTS_DIR=$(mktemp --directory)
+          export RELEASE_NOTES=$(mktemp)
+          OUTPUT=$(${{ inputs.release_prep_command }} ${{ inputs.tag_name || github.ref_name }} | jq --compact-output .)
+
+          echo "Release prep output:"
+          echo "${OUTPUT}"
+
+          # Parse the the release archives, making the paths absolute
+          # Store a comma-delimited list which is the format required by the `subject-path`
+          # input in actions/attest-build-provenance.
+          RELEASE_ARCHIVES=$(echo "${OUTPUT}" | jq --raw-output --arg artifactsDir "${ARTIFACTS_DIR}/" '.release_archives[] |= sub("^(?<path>[^/].*)";"\($artifactsDir)\(.path)") | .release_archives[]' | tr '\n' ',' | sed '$s/,$//')
+
+          echo "artifacts_dir=$ARTIFACTS_DIR" >> $GITHUB_OUTPUT
+          echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          echo "release_archives=$RELEASE_ARCHIVES" >> $GITHUB_OUTPUT
+
+      # The actions/attest-build-provenance action can only produce a single attestation with multiple
+      # subjects, rather than an attestation per subject, which we want. Create a single attestation
+      # with all release archives, then copy the same attestation to multiple files below.
+      - name: Attest release archive(s) provenance
+        id: attest_release_archive
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.release_prep.outputs.release_archives }}
+      
+      - name: Write release archive(s) attestation into intoto.jsonl
+        id: write_release_archive_attestation
+        run: |
+          ATTESTATIONS_DIR=$(mktemp --directory)
+          RELEASE_ARCHIVES="${{ steps.release_prep.outputs.release_archives }}"
+          SPACE_DELIMITED="${RELEASE_ARCHIVES//,/ }"
+          for ARCHIVE in $SPACE_DELIMITED; do
+              echo "${ARCHIVE}"
+              ATTESTATION_FILE="$(basename "${ARCHIVE}").intoto.jsonl"
+              echo "Writing attestation to ${ATTESTATION_FILE}"
+              cat ${{ steps.attest_release_archive.outputs.bundle-path }} | jq --compact-output > "${ATTESTATIONS_DIR}/${ATTESTATION_FILE}"
+          done
+          echo "release_archive_attestations_dir=${ATTESTATIONS_DIR}" >> $GITHUB_OUTPUT
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -79,7 +141,9 @@ jobs:
           prerelease: ${{ inputs.prerelease }}
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
-          body_path: release_notes.txt
+          body_path: ${{ steps.release_prep.outputs.release_notes }}
           fail_on_unmatched_files: true
-          files: ${{ inputs.release_files }}
+          files: |
+            ${{ steps.release_prep.outputs.artifacts_dir }}/*
+            ${{ steps.write_release_archive_attestation.outputs.release_archive_attestations_dir }}/*
           tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -34,7 +34,7 @@ on:
 
           The following arguments are passed to the script:
 
-            <tag_or_ref> The tag supplied as an input to this workflows, or ${{ github.ref_name }}.
+            <tag_or_ref> The tag supplied as an input to this workflows, or `github.ref_name`.
 
           The script must output a JSON blob with paths to release archives. The path can
           be absolute or relative to the ARTIFACTS_DIR. For example:


### PR DESCRIPTION
This updates the reusable release workflow to publish attestations and adds a new publish workflow for mirroring a release to the Bazel Central Registry.

The **publish** workflow can be set up to run automatically after a successful release run (configured in the calling repo), or manually. The manual option allows the publish to re-run from main, for the release tag, in case there was an error, for example, incorrect template files in .bcr.