### PR TITLE
fix: error if release files not found

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -108,12 +108,14 @@ jobs:
         with:
           name: release_files
           path: ${{ inputs.release_files }}
+          if-no-files-found: error
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
         id: upload-release-notes
         with:
           name: release_notes
           path: release_notes.txt
+          if-no-files-found: error
 
   attest:
     needs: build


### PR DESCRIPTION
By default, the actions/upload-artifact workflow doesn't fail if the files that are meant to be uploaded don't exist. It just warns and it's up to the users to dig through the GH Actions UI to find the warning message.

IMHO this is quite difficult becase the "build" job is actually green, so people won't usually be clicking there expecting to find an issue! Also, since the "build" job will be green, other jobs will attempt to run and fail with potentially weird error messages that are much harder to debug (e.g. attest will fail with "Error: Unhandled error: Error: string is no integer").