### PR TITLE
feat: add module_version input to release workflow

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -101,17 +101,18 @@ jobs:
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
     
       - name: Build release artifacts and prepare release notes
+        env:
+          TAG: ${{ inputs.tag_name || github.ref_name }}
+          VERSION: ${{ inputs.module_version }}
         run: |
           if [ ! -f ".github/workflows/release_prep.sh" ]; then
             echo "ERROR: create a .github/workflows/release_prep.sh script"
             exit 1
           fi
-          tag="${{ inputs.tag_name || github.ref_name }}"
-          version="${{ inputs.module_version }}"
-          if [ -z "$version" ]; then
-            version="${tag:1}"
+          if [ -z "$VERSION" ]; then
+            VERSION="${TAG:1}"
           fi
-          .github/workflows/release_prep.sh $tag $version > release_notes.txt
+          .github/workflows/release_prep.sh $TAG $VERSION > release_notes.txt
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
         id: upload-release-files


### PR DESCRIPTION
#### Description

Allow to provide a module version, if not provided, the first character is removed.

Related to https://github.com/bazel-contrib/publish-to-bcr/pull/293#pullrequestreview-3178803941