### PR TITLE
release_rulesets: make compatible with immutable releases

### DIFF
--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -194,11 +194,11 @@ jobs:
               artifactClient.downloadArtifact(ATTESTATIONS_ARTIFACT_ID, { path: 'attestations/'})
             ])
 
-      - name: Release
+      - name: Upload Draft Artifacts
         uses: softprops/action-gh-release@v2
         with:
           prerelease: ${{ inputs.prerelease }}
-          draft: ${{ inputs.draft }}
+          draft: true
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes/release_notes.txt
@@ -207,3 +207,13 @@ jobs:
           files: |
             release_files/**/*
             attestations/*
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: ${{ inputs.prerelease }}
+          draft: ${{ inputs.draft }}
+          # Use GH feature to populate the changelog automatically
+          generate_release_notes: true
+          body_path: release_notes/release_notes.txt
+          tag_name: ${{ inputs.tag_name }}


### PR DESCRIPTION
With immutable github releases, one cannot add artifacts after marking
the release as released; as that generates Github sigstore
attestation.

Hence call action-gh-release twice, once to upload files to a draft
release, and then marking it as released.

References:
- https://github.com/sugyan/claude-code-webui/commit/7765294d0a72040403b224ea441f45caaeb606ee
- https://github.com/softprops/action-gh-release/issues/653

This is needed I guess, until action-gh-release will automatically
always use a draft release to upload files.
