### PR TITLE
Feature/support multiple bazel versions

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -83,7 +83,7 @@ jobs:
     # Prepares the 'bazelversion' axis of the test matrix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: inputs.bazel_versions == ''
       # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
@@ -107,7 +107,9 @@ jobs:
           BAZEL_VERSIONS: ${{ needs.matrix-prep-bazelversion.outputs.bazelversions }}
         run: |
           exclude="$(
-            jq -cn \
+            jq \
+              --compact-output \
+              --null-input \
               --argjson input_exclude "$INPUT_EXCLUDE" \
               --argjson bazel_versions "$BAZEL_VERSIONS" '
                 def major:
@@ -143,9 +145,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: bazel-contrib/setup-bazel@0.18.0
+      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # 0.18.0
         with:
           repository-cache: ${{ inputs.mount_bazel_caches }}
           bazelrc: |
@@ -169,7 +171,7 @@ jobs:
         # Checks for the existence of test.sh in the folder. Downstream steps can use
         # steps.has_test_sh.outputs.files_exists as a conditional.
         id: has_test_sh
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
         with:
           files: "${{ matrix.folder }}/test.sh"
 

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -9,6 +9,11 @@ on:
   # https://github.blog/2022-02-10-using-reusable-workflows-github-actions
   workflow_call:
     inputs:
+      bazel_versions:
+        description: |
+          JSON-formatted array of Bazel versions to test with. For example, '["7.0.0", "8.x"]'.
+          If not set, defaults to the version specified in the .bazelversion file and 8.0.0.
+        type: string
       folders:
         required: true
         # JSON is needed because list is not supported:
@@ -79,14 +84,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        if: inputs.bazel_versions == ''
       # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
+        if: inputs.bazel_versions == ''
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_8
+        if: inputs.bazel_versions == ''
         run: echo "bazelversion=8.0.0" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like ["<version from .bazelversion>", "x.y.z"]
-      bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
+      bazelversions: ${{ inputs.bazel_versions != '' && inputs.bazel_versions || toJSON(steps.*.outputs.bazelversion) }}
+
+  matrix-prep-exclude:
+    # Prepares the 'exclude' axis of the test matrix
+    runs-on: ubuntu-latest
+    needs:
+      - matrix-prep-bazelversion
+    steps:
+      - id: exclude
+        env:
+          INPUT_EXCLUDE: ${{ inputs.exclude }}
+          BAZEL_VERSIONS: ${{ needs.matrix-prep-bazelversion.outputs.bazelversions }}
+        run: |
+          exclude="$(
+            jq -cn \
+              --argjson input_exclude "$INPUT_EXCLUDE" \
+              --argjson bazel_versions "$BAZEL_VERSIONS" '
+                def major:
+                  (capture("^(?<major>[0-9]+)") | .major | tonumber)? // -1;
+                ($bazel_versions
+                  | map(select((. | major) >= 9) | {bazelversion: ., bzlmodEnabled: false})) as $bazel9_or_later
+                | ($input_exclude + $bazel9_or_later | unique)
+              '
+          )"
+          echo "exclude=$exclude" >> "$GITHUB_OUTPUT"
+    outputs:
+      exclude: ${{ steps.exclude.outputs.exclude }}
 
   test:
     # The type of runner that the job will run on
@@ -95,6 +128,7 @@ jobs:
     needs:
       - matrix-prep-bazelversion
       - matrix-prep-os
+      - matrix-prep-exclude
 
     # Run bazel test in each workspace with each version of Bazel supported
     strategy:
@@ -104,7 +138,7 @@ jobs:
         bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder: ${{ fromJSON(inputs.folders) }}
         bzlmodEnabled: [true, false]
-        exclude: ${{ fromJSON(inputs.exclude) }}
+        exclude: ${{ fromJSON(needs.matrix-prep-exclude.outputs.exclude) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -78,7 +78,7 @@ jobs:
     # Prepares the 'bazelversion' axis of the test matrix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # NB: we assume this is Bazel 7
       - id: bazel_from_bazelversion
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
@@ -109,9 +109,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: bazel-contrib/setup-bazel@0.8.0
+      - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           repository-cache: ${{ inputs.mount_bazel_caches }}
           bazelrc: |

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
 
-      - uses: bazel-contrib/setup-bazel@0.14.0
+      - uses: bazel-contrib/setup-bazel@0.18.0
         with:
           disk-cache: ${{ inputs.mount_bazel_caches }}
           external-cache: ${{ inputs.mount_bazel_caches }}
@@ -93,8 +93,8 @@ jobs:
 
       # Fetch built artifacts (if any) from earlier jobs, which the release script may want to read.
       # Extract into ${GITHUB_WORKSPACE}/artifacts/*
-      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-    
+      - uses: actions/download-artifact@v7
+
       - name: Build release artifacts and prepare release notes
         run: |
           if [ ! -f ".github/workflows/release_prep.sh" ]; then
@@ -103,13 +103,13 @@ jobs:
           fi
           .github/workflows/release_prep.sh ${{ inputs.tag_name || github.ref_name }} > release_notes.txt
 
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
+      - uses: actions/upload-artifact@v6
         id: upload-release-files
         with:
           name: release_files
           path: ${{ inputs.release_files }}
 
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
+      - uses: actions/upload-artifact@v6
         id: upload-release-notes
         with:
           name: release_notes
@@ -124,23 +124,15 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      # actions/download-artifact@v4 does not yet support downloading via the immutable artifact-id,
-      # but the Javascript library does. See: https://github.com/actions/download-artifact/issues/349
-      - run: npm install @actions/artifact@2.1.9
-      - name: download-release-files
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          ARTIFACT_ID: ${{ needs.build.outputs.release-files-artifact-id }}
+      - uses: actions/download-artifact@v7
         with:
-          script: |
-            const {default: artifactClient} = require('@actions/artifact')
-            const { ARTIFACT_ID } = process.env
-            await artifactClient.downloadArtifact(ARTIFACT_ID, { path: 'release_files/'})
+          artifact-ids: ${{ needs.build.outputs.release-files-artifact-id }}
+          path: release_files
 
       # https://github.com/actions/attest-build-provenance
       - name: Attest release files
         id: attest_release
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v3
         with:
           subject-path: release_files/**/*
 
@@ -163,7 +155,7 @@ jobs:
             fi
           done
           echo "release_archive_attestations_dir=${ATTESTATIONS_DIR}" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 #v4.6.0
+      - uses: actions/upload-artifact@v6
         id: upload-attestations
         with:
           name: attestations
@@ -175,25 +167,18 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      # actions/download-artifact@v4 does not yet support downloading via the immutable artifact-id,
-      # but the Javascript library does. See: https://github.com/actions/download-artifact/issues/349
-      - run: npm install @actions/artifact@2.1.9
-      - name: download-artifacts
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          RELEASE_FILES_ARTIFACT_ID: ${{ needs.build.outputs.release-files-artifact-id }}
-          RELEASE_NOTES_ARTIFACT_ID: ${{ needs.build.outputs.release-notes-artifact-id }}
-          ATTESTATIONS_ARTIFACT_ID: ${{ needs.attest.outputs.attestations-artifact-id }}
+      - uses: actions/download-artifact@v7
         with:
-          script: |
-            const {default: artifactClient} = require('@actions/artifact')
-            const { RELEASE_FILES_ARTIFACT_ID, RELEASE_NOTES_ARTIFACT_ID, ATTESTATIONS_ARTIFACT_ID } = process.env
-            await Promise.all([
-              artifactClient.downloadArtifact(RELEASE_FILES_ARTIFACT_ID, { path: 'release_files/'}),
-              artifactClient.downloadArtifact(RELEASE_NOTES_ARTIFACT_ID, { path: 'release_notes/'}),
-              artifactClient.downloadArtifact(ATTESTATIONS_ARTIFACT_ID, { path: 'attestations/'})
-            ])
-
+          artifact-ids: ${{ needs.build.outputs.release-files-artifact-id }}
+          path: release_files
+      - uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.build.outputs.release-notes-artifact-id }}
+          path: release_notes
+      - uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.attest.outputs.attestations-artifact-id }}
+          path: attestations
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release_ruleset.yaml
+++ b/.github/workflows/release_ruleset.yaml
@@ -78,11 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag_name }}
 
-      - uses: bazel-contrib/setup-bazel@0.18.0
+      - uses: bazel-contrib/setup-bazel@083175551ceeceebc757ebee2127fde78840ca77 # v0.18.0
         with:
           disk-cache: ${{ inputs.mount_bazel_caches }}
           external-cache: ${{ inputs.mount_bazel_caches }}
@@ -93,7 +93,7 @@ jobs:
 
       # Fetch built artifacts (if any) from earlier jobs, which the release script may want to read.
       # Extract into ${GITHUB_WORKSPACE}/artifacts/*
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
 
       - name: Build release artifacts and prepare release notes
         run: |
@@ -103,13 +103,13 @@ jobs:
           fi
           .github/workflows/release_prep.sh ${{ inputs.tag_name || github.ref_name }} > release_notes.txt
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: upload-release-files
         with:
           name: release_files
           path: ${{ inputs.release_files }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: upload-release-notes
         with:
           name: release_notes
@@ -124,7 +124,7 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.build.outputs.release-files-artifact-id }}
           path: release_files
@@ -132,7 +132,7 @@ jobs:
       # https://github.com/actions/attest-build-provenance
       - name: Attest release files
         id: attest_release
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         with:
           subject-path: release_files/**/*
 
@@ -155,7 +155,7 @@ jobs:
             fi
           done
           echo "release_archive_attestations_dir=${ATTESTATIONS_DIR}" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         id: upload-attestations
         with:
           name: attestations
@@ -167,20 +167,20 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.build.outputs.release-files-artifact-id }}
           path: release_files
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.build.outputs.release-notes-artifact-id }}
           path: release_notes
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           artifact-ids: ${{ needs.attest.outputs.attestations-artifact-id }}
           path: attestations
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           prerelease: ${{ inputs.prerelease }}
           draft: ${{ inputs.draft }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 # Run hooks on commit stage
-default_stages: [commit]
+default_stages: [pre-commit]
 
 # Use a slightly older version of node by default
 # as the default uses a very new version of GLIBC

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"]
+}


### PR DESCRIPTION
- Add optional `bazel_versions` input to `bazel.yaml`.
- Keep existing default behavior when unset (.bazelversion + 8.0.0).
- Compute matrix exclude as union of `exclude` input  and auto-excludes for Bazel >=9 with bzlmodEnabled: false.
- Update workflow actions in CI/releasen and simplify artifact downloads via artifact-ids
  - `checkout@v6`
  - `setup-bazel@0.18.0`
  - `download-artifact@v7`
  - `upload-artifact@v6`
  - `attest-build-provenance@v3`
- Switch pre-commit default stage from commit to pre-commit.