### PR TITLE
chore: enable Bazel disk and external caches

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -45,15 +45,47 @@ on:
         default: "bazel test //..."
         description: |
           Bazel test command that may be overridden to set custom flags and targets.
-          The `--enable_bzlmod={true,false}`, `--disk_cache=~/.cache/bazel-disk-cache`,
-          and `--repository_cache=~/.cache/bazel-repository-cache` flags are
-          automatically appended to the command.
+          The `--enable_bzlmod={true,false}` flag and Bazel cache flags are
+          configured automatically.
         type: string
       mount_bazel_caches:
         default: true
         description: |
           Whether to enable caching in the bazel-contrib/setup-bazel action.
         type: boolean
+      bazelisk_cache:
+        default: true
+        description: |
+          Whether to cache Bazelisk downloads when mount_bazel_caches is enabled.
+        type: boolean
+      disk_cache:
+        default: "true"
+        description: |
+          Whether to enable Bazel disk caching when mount_bazel_caches is enabled.
+          String values are passed through to setup-bazel as cache key discriminators.
+        type: string
+      external_cache:
+        default: "true"
+        description: |
+          Whether to cache external repositories when mount_bazel_caches is enabled.
+          String values are passed through to setup-bazel.
+        type: string
+      repository_cache:
+        default: "true"
+        description: |
+          Whether to enable Bazel repository caching when mount_bazel_caches is enabled.
+          String values are passed through to setup-bazel as cache key files.
+        type: string
+      cache_save:
+        default: true
+        description: |
+          Whether to save restored caches after the run. Pull request events never save caches.
+        type: boolean
+      cache_version:
+        default: "1"
+        description: |
+          Version suffix for setup-bazel cache keys.
+        type: string
 
 jobs:
   # matrix-prep-* steps generate JSON used to create a dynamic actions matrix.
@@ -149,7 +181,12 @@ jobs:
 
       - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
         with:
-          repository-cache: ${{ inputs.mount_bazel_caches }}
+          bazelisk-cache: ${{ inputs.mount_bazel_caches && inputs.bazelisk_cache }}
+          disk-cache: ${{ inputs.mount_bazel_caches && inputs.disk_cache != 'false' && (inputs.disk_cache == 'true' && format('bazel-{0}', matrix.bazelversion) || inputs.disk_cache) }}
+          external-cache: ${{ inputs.mount_bazel_caches && inputs.external_cache != 'false' && inputs.external_cache }}
+          repository-cache: ${{ inputs.mount_bazel_caches && inputs.repository_cache != 'false' && inputs.repository_cache }}
+          cache-save: ${{ inputs.mount_bazel_caches && inputs.cache_save }}
+          cache-version: ${{ inputs.cache_version }}
           bazelrc: |
             common --announce_rc
             common --color=yes


### PR DESCRIPTION
## Summary

Configure Bazel-related caches in the reusable CI workflow through `setup-bazel@0.19.0`.

This adds workflow inputs for the individual cache controls:

- `bazelisk_cache`
- `disk_cache`
- `external_cache`
- `repository_cache`
- `cache_save`
- `cache_version`

`mount_bazel_caches` remains the global switch for all setup-bazel caching.

The cache inputs mirror setup-bazel behavior where useful: `disk_cache`, `external_cache`, and `repository_cache` accept string values so callers can pass through setup-bazel cache discriminators or cache key inputs. The default `disk_cache: "true"` keeps the workflow’s versioned disk cache key, so different Bazel versions do not share one disk cache.

## Testing

- [CI run no cache](https://github.com/bazel-contrib/rules_d/actions/runs/25645040909/job/75272258844?pr=203): 6m19s
- [CI run with cache](https://github.com/bazel-contrib/rules_d/actions/runs/25645283753/job/75272947979?pr=203): 37s

