### PR TITLE
fix: key bazel disk cache by folder and bzlmod mode too

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -182,7 +182,7 @@ jobs:
       - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
         with:
           bazelisk-cache: ${{ inputs.mount_bazel_caches && inputs.bazelisk_cache }}
-          disk-cache: ${{ inputs.mount_bazel_caches && inputs.disk_cache != 'false' && (inputs.disk_cache == 'true' && format('bazel-{0}', matrix.bazelversion) || inputs.disk_cache) }}
+          disk-cache: ${{ inputs.mount_bazel_caches && inputs.disk_cache != 'false' && (inputs.disk_cache == 'true' && format('{0}-{1}-{2}', matrix.bazelversion, matrix.folder, matrix.bzlmodEnabled) || inputs.disk_cache) }}
           external-cache: ${{ inputs.mount_bazel_caches && inputs.external_cache != 'false' && inputs.external_cache }}
           repository-cache: ${{ inputs.mount_bazel_caches && inputs.repository_cache != 'false' && inputs.repository_cache }}
           cache-save: ${{ inputs.mount_bazel_caches && inputs.cache_save }}


### PR DESCRIPTION
## Summary

- Key the default Bazel disk cache by Bazel version, folder, and Bzlmod mode
- Avoid poor cache reuse when different folders build different target scopes
- Avoid sharing disk cache entries between Bzlmod and WORKSPACE-mode builds
- Keep custom `disk_cache` input values passed through unchanged

## Testing

- Parsed `.github/workflows/bazel.yaml` with PyYAML
